### PR TITLE
removing the need for tokens to be set before consuming gists or presets

### DIFF
--- a/gist_magic/extensions/pretty.py
+++ b/gist_magic/extensions/pretty.py
@@ -63,7 +63,12 @@ class PrettyGist(object):
 
     def _repr_html_(self):
         if self.display:
-            url = "https://gist.github.com/%s/%s.js" % (self.gist.owner["login"], self.gist.id)
+            try:
+              owner = self.gist.owner["login"]
+            except AttributeError:
+              owner = 'anonymous'
+
+            url = "https://gist.github.com/%s/%s.js" % (owner, self.gist.id)
             resp = urlopen(url)
             jsdata = resp.read()
             matches = [re.findall(r"document\.write\([\'\"](.+)[\'\"]\)", line, re.DOTALL) for line in jsdata.splitlines()]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='gist-magic',
-      version='0.1',
+      version='0.2',
       description='IPython magics to work with gists',
       url='https://github.com/pramukta/gist-magic',
       author='Pramukta Kumar',


### PR DESCRIPTION
This removes the concept the gh access tokens are needed to do consume presets and gists. They are still needed for lists, create, delete, and updates...

Once this is merged I'll publish a new version to pypi.
